### PR TITLE
Fixed issue when attributes with '0' value are not exported

### DIFF
--- a/svg.export.js
+++ b/svg.export.js
@@ -108,7 +108,7 @@
           value = value.replace(/"/g,"'")
         
         /* build value */
-        if (value && key != 'data-svg-export-attr' && key != 'href') {
+        if (key != 'data-svg-export-attr' && key != 'href') {
           if (key != 'stroke' || parseFloat(exportAttrs['stroke-width']) > 0)
             attr.push(key + '="' + value + '"')
         }


### PR DESCRIPTION
Removed check whether the variable "value" is equivalent to "false" in the condition of building attribute value string.
